### PR TITLE
Fix/display default image

### DIFF
--- a/app/serializers/community_serializer.rb
+++ b/app/serializers/community_serializer.rb
@@ -14,6 +14,10 @@
 class CommunitySerializer < ActiveModel::Serializer
   attributes :id, :name, :url, :description, :created_at, :updated_at, :logo
 
+  def logo
+    ActionController::Base.helpers.image_url(object.logo_url(:thumb))
+  end
+
   def description
     MarkdownHelper.markdown(object.description)
   end

--- a/app/serializers/personality_serializer.rb
+++ b/app/serializers/personality_serializer.rb
@@ -29,6 +29,10 @@
 class PersonalitySerializer < ActiveModel::Serializer
   attributes :id, :name, :description, :role, :image
 
+  def image
+    ActionController::Base.helpers.image_url(object.image_url(:thumb))
+  end
+
   def description
     MarkdownHelper.markdown(object.description)
   end

--- a/app/serializers/radio_serializer.rb
+++ b/app/serializers/radio_serializer.rb
@@ -19,6 +19,10 @@
 class RadioSerializer < ActiveModel::Serializer
   attributes :id, :title, :description, :mp3, :youtube_url, :podcast_url, :image, :duration, :published_at, :created_at, :updated_at
 
+  def image
+    ActionController::Base.helpers.image_url(object.image_url(:thumb))
+  end
+
   def description
     MarkdownHelper.markdown(object.description)
   end

--- a/frontend/src/pages/top.vue
+++ b/frontend/src/pages/top.vue
@@ -18,7 +18,7 @@
       <h2 class="ui header">新着情報</h2>
       <div class="ui items" v-for="radio in newRadios">
         <new-item
-          :image-path="radio.image.url"
+          :image-path="radio.image"
           :item-path="radio.itemPath"
           type="radio"
           :title="radio.title"


### PR DESCRIPTION
closed #104 

# やったこと
デフォルト画像がきちんと表示されるようにしました。
(digest付きのpathが生成されるようにしました。)

# やってないこと
画像の生データへのアクセスができなくなった(できなくした)
→ 今のところ必要ないと思ったので。