### PR TITLE
公開中の記事を編集しても公開日が更新されないようにした

### DIFF
--- a/app/controllers/admin/radios_controller.rb
+++ b/app/controllers/admin/radios_controller.rb
@@ -39,12 +39,15 @@ class Admin::RadiosController < Admin::BaseController
 
   # PATCH/PUT /radios/1
   def update
-    @radio.published_at = published_at_from(
-      params[:radio][:status],
-      Time.zone.parse(
-        datetime_select_to_a(params[:radio], :reserve_time).join,
-      ),
-    )
+    unless @radio.publish? && params[:radio][:status] == "publish"
+      @radio.published_at = published_at_from(
+          params[:radio][:status],
+          Time.zone.parse(
+              datetime_select_to_a(params[:radio], :reserve_time).join,
+          ),
+      )
+    end
+
     if @radio.update(radio_params)
       redirect_to admin_radio_path(@radio), notice: "Radio was successfully updated."
     else

--- a/app/controllers/admin/radios_controller.rb
+++ b/app/controllers/admin/radios_controller.rb
@@ -41,10 +41,10 @@ class Admin::RadiosController < Admin::BaseController
   def update
     unless @radio.publish? && params[:radio][:status] == "publish"
       @radio.published_at = published_at_from(
-          params[:radio][:status],
-          Time.zone.parse(
-              datetime_select_to_a(params[:radio], :reserve_time).join,
-          ),
+        params[:radio][:status],
+        Time.zone.parse(
+          datetime_select_to_a(params[:radio], :reserve_time).join,
+        ),
       )
     end
 

--- a/app/views/admin/radios/index.html.erb
+++ b/app/views/admin/radios/index.html.erb
@@ -14,6 +14,7 @@
     <tr>
       <th><%= Radio.human_attribute_name('title') %></th>
       <th><%= Radio.human_attribute_name('description') %></th>
+      <th><%= Radio.human_attribute_name('status') %></th>
       <th></th>
     </tr>
   </thead>
@@ -23,6 +24,7 @@
       <tr>
         <td><%= radio.title %></td>
         <td><%= truncate(radio.description) if radio.description %></td>
+        <td><%= status_badge(radio) %></td>
         <td>
           <%= Admin::RadioViewObject.link_to_show(current_personality, radio) %>
           <%= Admin::RadioViewObject.link_to_edit(current_personality, radio) %>

--- a/config/locales/models/radio.ja.yml
+++ b/config/locales/models/radio.ja.yml
@@ -16,5 +16,5 @@ ja:
         podcast_url: podcast
         published_at: 投稿日時
 
-        status: 公開ステータス
+        status: ステータス
         reserve_time: 公開予定日時


### PR DESCRIPTION
closed #143 

# やったこと
公開中の記事を編集しても公開日が更新されないようにしました。
radios/indexにステータスが表示されるようにしました。

# やってないこと
特になし。
