### PR TITLE
ニックネームをいい感じに表示する

### DIFF
--- a/app/controllers/admin/personalities_controller.rb
+++ b/app/controllers/admin/personalities_controller.rb
@@ -92,7 +92,7 @@ class Admin::PersonalitiesController < Admin::BaseController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def personality_params
-      params.require(:personality).permit(:name, :image, :description, :tag_list)
+      params.require(:personality).permit(:name, :nickname, :image, :description, :tag_list)
     end
 
     def provisional_personality_params

--- a/app/models/personality.rb
+++ b/app/models/personality.rb
@@ -19,6 +19,7 @@
 #  description            :text(65535)
 #  role                   :integer          default(0), not null
 #  image                  :string(255)
+#  nickname               :string(255)
 #
 # Indexes
 #

--- a/app/serializers/personality_serializer.rb
+++ b/app/serializers/personality_serializer.rb
@@ -28,7 +28,7 @@
 #
 
 class PersonalitySerializer < ActiveModel::Serializer
-  attributes :id, :name, :description, :role, :image, :tag_list
+  attributes :id, :name, :nickname, :description, :role, :image, :tag_list
 
   has_many :radios
 

--- a/app/serializers/personality_serializer.rb
+++ b/app/serializers/personality_serializer.rb
@@ -19,6 +19,7 @@
 #  description            :text(65535)
 #  role                   :integer          default(0), not null
 #  image                  :string(255)
+#  nickname               :string(255)
 #
 # Indexes
 #

--- a/app/views/admin/personalities/_form.html.erb
+++ b/app/views/admin/personalities/_form.html.erb
@@ -9,6 +9,13 @@
   </div>
 
   <div class="form-group row">
+    <%= form.label :nickname, class: 'col-2 col-form-label' %>
+    <div class="col-10">
+      <%= form.text_field :nickname, class: 'form-control' %>
+    </div>
+  </div>
+
+  <div class="form-group row">
     <%= form.label :image, class: 'col-2 col-form-label' %>
     <div class="col-10">
       <%= form.file_field :image %>

--- a/app/views/admin/personalities/show.html.erb
+++ b/app/views/admin/personalities/show.html.erb
@@ -6,6 +6,11 @@
 </dl>
 
 <dl class="dl-horizontal">
+  <dt><strong><%= Personality.human_attribute_name('nickname') %> :</strong></dt>
+  <dd><%= @personality.nickname %></dd>
+</dl>
+
+<dl class="dl-horizontal">
   <dt><strong><%= Personality.human_attribute_name('image') %> :</strong></dt>
   <dd><%= image_tag @personality.image_url(:thumb) %></dd>
 </dl>

--- a/config/locales/models/personality.ja.yml
+++ b/config/locales/models/personality.ja.yml
@@ -5,6 +5,7 @@ ja:
     attributes:
       personality:
         name: 名前
+        nickname: ニックネーム
         image: 写真
         description: 自己紹介
         role: 権限

--- a/db/fixtures/10_personality.rb
+++ b/db/fixtures/10_personality.rb
@@ -3,6 +3,7 @@ raise StandardError, "production環境では利用できません" if Rails.env.
 Personality.seed do |p|
   p.id = 1
   p.name = "新谷 哲平"
+  p.nickname = "てっぺー"
   p.email = "shintani@example.com"
   p.tag_list = "OB,開発"
   p.description = <<~TEXT
@@ -19,6 +20,7 @@ end
 Personality.seed do |p|
   p.id = 2
   p.name = "中村 優"
+  p.nickname = "ちゃんゆー"
   p.email = "nakamura@example.com"
   p.tag_list = "専攻科,開発,画伯"
   p.description = <<~TEXT
@@ -62,6 +64,7 @@ end
 Personality.seed do |p|
   p.id = 5
   p.name = "ふが ふが子"
+  p.nickname = "ふが子"
   p.email = "fuga@example.com"
   p.tag_list = "ほげ,ふが"
   p.description = "ふが" * 50

--- a/db/migrate/20180116035535_add_nickname_to_personalities.rb
+++ b/db/migrate/20180116035535_add_nickname_to_personalities.rb
@@ -1,0 +1,5 @@
+class AddNicknameToPersonalities < ActiveRecord::Migration[5.1]
+  def change
+    add_column :personalities, :nickname, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171223071451) do
+ActiveRecord::Schema.define(version: 20180116035535) do
 
   create_table "communities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name", null: false
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 20171223071451) do
     t.text "description"
     t.integer "role", default: 0, null: false
     t.string "image"
+    t.string "nickname"
     t.index ["email"], name: "index_personalities_on_email", unique: true
     t.index ["reset_password_token"], name: "index_personalities_on_reset_password_token", unique: true
   end

--- a/frontend/src/components/personality-card.vue
+++ b/frontend/src/components/personality-card.vue
@@ -5,8 +5,8 @@
     </div>
     <div class="content">
       <div class="header">{{ name }}</div>
-      <div class="meta">
-        <span v-for="tag in tags">
+      <div class="ui tag labels">
+        <span class="ui label" v-for="tag in tags">
           {{ tag }}
         </span>
       </div>

--- a/frontend/src/components/personality-card.vue
+++ b/frontend/src/components/personality-card.vue
@@ -4,7 +4,8 @@
       <img v-bind:src="imagePath">
     </div>
     <div class="content">
-      <div class="header">{{ name }}</div>
+      <span class="name">{{ name }}</span>
+      <span class="nickname">{{ nickname }}</span>
       <div class="ui tag labels">
         <span class="ui label" v-for="tag in tags">
           {{ tag }}
@@ -28,6 +29,9 @@ module.exports = {
       default: '名前を取得できませんでした',
       required: true
     },
+    nickname: {
+      type: String,
+    },
     description: {
       type: String,
       default: '自己紹介を取得できませんでした',
@@ -47,4 +51,19 @@ module.exports = {
 }
 </script>
 
-<style></style>
+<style>
+.name {
+  color: #000000;
+  font-weight: bold;
+  font-size: 22px;
+  margin-right: 10px;
+}
+
+.nickname {
+  color: #888888;
+}
+
+.tag {
+  margin-top: 5px;
+}
+</style>

--- a/frontend/src/components/personality-card.vue
+++ b/frontend/src/components/personality-card.vue
@@ -51,7 +51,7 @@ module.exports = {
 }
 </script>
 
-<style>
+<style scoped>
 .name {
   color: #000000;
   font-weight: bold;

--- a/frontend/src/components/personality-filter.vue
+++ b/frontend/src/components/personality-filter.vue
@@ -7,6 +7,7 @@
   <div class="personality-icon" @click="clickPersonalityIcon(personality.id)" v-for="personality in personalities">
     <img class="personality-icon-image" width="100%" :src="personality.image">
     <p class="personality-name">{{ personality.name }}</p>
+    <p class="personality-nickname">{{ personality.nickname }}</p>
   </div>
 </div>
 </template>
@@ -62,6 +63,14 @@ module.exports = {
 .personality-name {
   text-align: center;
   margin-top: 10px;
+  margin-bottom: 0;
+}
+
+.personality-nickname {
+  font-size: 13px;
+  color: #999999;
+  text-align: center;
+  margin-top: 0;
   margin-bottom: 10px;
 }
 </style>

--- a/frontend/src/components/personality-small.vue
+++ b/frontend/src/components/personality-small.vue
@@ -4,7 +4,12 @@
       <img :src="imagePath">
     </router-link>
     <div class="middle aligned content">
-      <router-link class="header" :to="{ name: 'personality', params: { id: id }}">{{ name }}</router-link>
+      <router-link class="header" :to="{ name: 'personality', params: { id: id }}">
+        <div class="names">
+          <h2 class="name">{{ name }}</h2>
+          <div class="nickname">{{ nickname }}</div>
+        </div>
+      </router-link>
       <div class="description">
         <p v-html="description"></p>
       </div>
@@ -25,6 +30,9 @@ module.exports = {
       default: '名前を取得できませんでした',
       required: true
     },
+    nickname: {
+      type: String,
+    },
     description: {
       type: String,
       default: '自己紹介を取得できませんでした',
@@ -38,3 +46,18 @@ module.exports = {
   }
 }
 </script>
+
+<style scoped>
+.name {
+  font-size: 20px;
+  display: inline-block;
+  margin-bottom: 0;
+}
+
+.nickname {
+  font-size: 16px;
+  font-weight: normal;
+  display: inline-block;
+  color: #888888;
+}
+</style>

--- a/frontend/src/pages/personalities.vue
+++ b/frontend/src/pages/personalities.vue
@@ -7,6 +7,7 @@
           :key="personality.id"
           :id="personality.id"
           :name="personality.name"
+          :nickname="personality.nickname"
           :description="personality.description"
           :image-path="personality.image"
           :tags="personality.tag_list">

--- a/frontend/src/pages/personality.vue
+++ b/frontend/src/pages/personality.vue
@@ -3,7 +3,10 @@
     <div class="main">
       <div class="ui text container">
         <article>
-          <h2 class="ui header">{{ personality.name }}</h2>
+          <div class="names">
+            <h2 class="name">{{ personality.name }}</h2>
+            <div class="nickname">{{ personality.nickname }}</div>
+          </div>
           <img class="ui small right floated image" :src="personality.image">
           <h3 class="ui header">自己紹介</h3>
           <p v-html="personality.description"></p>
@@ -103,5 +106,14 @@ module.exports = {
 .main {
   padding-top: 80px;
   padding-bottom: 40px;
+}
+
+.name {
+  display: inline;
+}
+
+.nickname {
+  display: inline;
+  color: #888888;
 }
 </style>

--- a/frontend/src/pages/personality.vue
+++ b/frontend/src/pages/personality.vue
@@ -31,6 +31,7 @@
             :key="personality.id"
             :id="personality.id"
             :name="personality.name"
+            :nickname="personality.nickname"
             :description="personality.description"
             :image-path="personality.image">
           </personality-small>


### PR DESCRIPTION
closed #194 

# やったこと
* パーソナリティにニックネームを追加して編集できるようにした
* 各所にnicknameを表示させるようにした

# やってないこと
* 特になし

脱semantic-uiを心がけてみました。

<img width="1280" alt="2018-01-16 17 52 05" src="https://user-images.githubusercontent.com/13253769/34979887-13800c18-fae6-11e7-9312-8f9ad0aca5df.png">
<img width="276" alt="2018-01-16 17 52 24" src="https://user-images.githubusercontent.com/13253769/34979898-1a3494d4-fae6-11e7-9391-d490d720d673.png">
<img width="263" alt="2018-01-16 17 52 09" src="https://user-images.githubusercontent.com/13253769/34979900-1a5645f2-fae6-11e7-9514-18fbcd4350bd.png">

