### PR TITLE
jargonのseed_fuがproduction環境で実行されないようにした

### DIFF
--- a/db/fixtures/50_jargon.rb
+++ b/db/fixtures/50_jargon.rb
@@ -1,3 +1,5 @@
+raise StandardError, "production環境では利用できません" if Rails.env.production?
+
 radio_ids = Radio.pluck(:id)
 (1..50).each do |i|
   Jargon.seed do |j|


### PR DESCRIPTION
# やったこと
jargonのseedがproductionで動くようになっていたので修正しました。

# やってないこと
特にないです。
