### PR TITLE
appearedからon_publicを外した

### DIFF
--- a/app/controllers/api/v1/personalities_controller.rb
+++ b/app/controllers/api/v1/personalities_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::PersonalitiesController < Api::V1::BaseController
   end
 
   def appeared
-    render json: Personality.appeared
+    render json: Personality.appeared.on_public
   end
 
   def show

--- a/app/models/personality.rb
+++ b/app/models/personality.rb
@@ -53,7 +53,7 @@ class Personality < ApplicationRecord
       id: RadioPersonality.where(
         radio_id: Radio.published.select(:id),
       ).select(:personality_id),
-    ).on_public
+    )
   }
 
   def member?


### PR DESCRIPTION
# やったこと
`Personality.appeared` は出演したことのあるパーソナリティを取得する。
そこに `Personality.on_public` がついているのは変なので取り除いてcontrollerに移した。

# やってないこと
特になし。
