### PR TITLE
ラジオ詳細の他のラジオのパーソナリティが違っていたのを修正

### DIFF
--- a/frontend/src/pages/radio.vue
+++ b/frontend/src/pages/radio.vue
@@ -32,7 +32,7 @@
         :title="newRadio.title"
         :description="newRadio.description"
         :mp3-url="newRadio.mp3.url"
-        :personalities="radio.personalities"
+        :personalities="newRadio.personalities"
         :date="newRadio.created_at">
       </radio-preview>
     </div>


### PR DESCRIPTION
closed #188 

# やったこと
他のラジオのパーソナリティに間違えてラジオ詳細のパーソナリティが入っていたのを修正しました。

# やってないこと
特になし。
