### PR TITLE
podcastへの動線を貼った

### DIFF
--- a/frontend/src/components/how-to-podcast-link.vue
+++ b/frontend/src/components/how-to-podcast-link.vue
@@ -1,14 +1,18 @@
 <template>
-<transition name="fade">
-  <div v-if="visible" class="how-to-podcast">
-    <div class="how-to-podcast-link">
-      <p>Podcastで聞いてみる？</p>
+<div>
+  <transition name="fade">
+    <div v-if="visible" class="how-to-podcast">
+      <a @click="showModal = true" class="how-to-podcast-link">
+        <p>Podcastで聞いてみる？</p>
+      </a>
+      <a @click="visible = false" class="delete-link">
+        <p>×</p>
+      </a>
     </div>
-    <a @click="visible = false" class="delete-link">
-      <p>×</p>
-    </a>
-  </div>
-</transition>
+  </transition>
+  <how-to-podcast-modal v-if="showModal" @close="showModal = false">
+  </how-to-podcast-modal>
+</div>
 </template>
 
 <script>
@@ -16,6 +20,7 @@ module.exports = {
   data: function () {
     return {
       visible: true,
+      showModal: false,
     }
   },
 }

--- a/frontend/src/components/how-to-podcast-link.vue
+++ b/frontend/src/components/how-to-podcast-link.vue
@@ -1,10 +1,10 @@
 <template>
 <transition name="fade">
-  <div v-if="show" class="how-to-podcast">
+  <div v-if="visible" class="how-to-podcast">
     <div class="how-to-podcast-link">
       <p>Podcastで聞いてみる？</p>
     </div>
-    <a @click="show = false" class="delete-link">
+    <a @click="visible = false" class="delete-link">
       <p>×</p>
     </a>
   </div>
@@ -15,10 +15,9 @@
 module.exports = {
   data: function () {
     return {
-      show: true
+      visible: true,
     }
   },
-  props: {},
 }
 </script>
 

--- a/frontend/src/components/how-to-podcast-link.vue
+++ b/frontend/src/components/how-to-podcast-link.vue
@@ -1,0 +1,47 @@
+<template>
+<div class="how-to-podcast">
+  <div class="how-to-podcast-link">
+    <p>Podcastで聞いてみる？</p>
+  </div>
+  <div class="delete-link">
+    <p>×</p>
+  </div>
+</div>
+</template>
+
+<script>
+module.exports = {
+  props: {},
+}
+</script>
+
+<style scoped>
+.how-to-podcast {
+  color: #DCEEF7;
+  width: 270px;
+  margin: 0 auto;
+  font-size: 18px;
+}
+
+.how-to-podcast-link {
+  width: 235px;
+  height: 40px;
+  background-color: #40AEC7;
+  border: solid 1px #C0E4F5;
+  border-radius: 20px 0 0 20px;
+  text-align: center;
+  display: table-cell;
+  vertical-align: middle;
+}
+
+.delete-link {
+  width: 35px;
+  height: 40px;
+  background-color: #40AEC7;
+  border: solid 1px #C0E4F5;
+  border-radius: 0 20px 20px 0;
+  text-align: center;
+  display: table-cell;
+  vertical-align: middle;
+}
+</style>

--- a/frontend/src/components/how-to-podcast-link.vue
+++ b/frontend/src/components/how-to-podcast-link.vue
@@ -2,7 +2,7 @@
 <div>
   <transition name="fade">
     <div v-if="visible" class="how-to-podcast">
-      <a @click="showModal = true" class="how-to-podcast-link">
+      <a @click="openModal()" class="how-to-podcast-link">
         <p>Podcastで聞いてみる？</p>
       </a>
       <a @click="visible = false" class="delete-link">
@@ -10,7 +10,7 @@
       </a>
     </div>
   </transition>
-  <how-to-podcast-modal v-if="showModal" @close="showModal = false">
+  <how-to-podcast-modal v-if="showModal" @close="closeModal()">
   </how-to-podcast-modal>
 </div>
 </template>
@@ -23,6 +23,17 @@ module.exports = {
       showModal: false,
     }
   },
+
+  methods: {
+    openModal: function() {
+      this.showModal = true
+      $('body').css('overflow', 'hidden')
+    },
+    closeModal: function() {
+      this.showModal = false
+      $('body').css('overflow', 'auto')
+    }
+  }
 }
 </script>
 

--- a/frontend/src/components/how-to-podcast-link.vue
+++ b/frontend/src/components/how-to-podcast-link.vue
@@ -1,23 +1,34 @@
 <template>
-<div class="how-to-podcast">
-  <div class="how-to-podcast-link">
-    <p>Podcastで聞いてみる？</p>
+<transition name="fade">
+  <div v-if="show" class="how-to-podcast">
+    <div class="how-to-podcast-link">
+      <p>Podcastで聞いてみる？</p>
+    </div>
+    <a @click="show = false" class="delete-link">
+      <p>×</p>
+    </a>
   </div>
-  <div class="delete-link">
-    <p>×</p>
-  </div>
-</div>
+</transition>
 </template>
 
 <script>
 module.exports = {
+  data: function () {
+    return {
+      show: true
+    }
+  },
   props: {},
 }
 </script>
 
 <style scoped>
 .how-to-podcast {
-  color: #DCEEF7;
+  position: fixed;
+  bottom: 5%;
+  left:calc(50% - 270px/2);
+  z-index: 10;
+  color: #e4f5ff;
   width: 270px;
   margin: 0 auto;
   font-size: 18px;
@@ -27,8 +38,9 @@ module.exports = {
   width: 235px;
   height: 40px;
   background-color: #40AEC7;
-  border: solid 1px #C0E4F5;
+  border-right: solid 1px #C0E4F5;
   border-radius: 20px 0 0 20px;
+  padding-left: 10px;
   text-align: center;
   display: table-cell;
   vertical-align: middle;
@@ -38,10 +50,17 @@ module.exports = {
   width: 35px;
   height: 40px;
   background-color: #40AEC7;
-  border: solid 1px #C0E4F5;
   border-radius: 0 20px 20px 0;
+  padding-right: 5px;
   text-align: center;
   display: table-cell;
   vertical-align: middle;
+}
+
+.fade-enter-active, .fade-leave-active {
+  transition: opacity .7s;
+}
+.fade-enter, .fade-leave-to {
+  opacity: 0;
 }
 </style>

--- a/frontend/src/components/how-to-podcast-modal.vue
+++ b/frontend/src/components/how-to-podcast-modal.vue
@@ -3,15 +3,18 @@
   <div class="modal-mask">
     <div class="modal-wrapper">
       <div class="modal-container">
+        <div class="modal-close" @click="$emit('close')">
+          <span class="modal-close-large">×</span>
+        </div>
         <div class="modal-body">
           <how-to-use-podcast></how-to-use-podcast>
         </div>
 
         <div class="modal-footer">
-          default footer
-          <button class="modal-default-button" @click="$emit('close')">
-            OK
-          </button>
+          <div class="modal-close" @click="$emit('close')">
+            閉じる
+          </div>
+        </div>
         </div>
       </div>
     </div>
@@ -44,15 +47,14 @@ module.exports = {
 
 .modal-container {
   overflow: auto;
-  width: 300px;
+  width: 90%;
   height: 100%;
-  margin: 0px auto;
-  padding: 20px 30px;
+  margin: 20px auto 0 auto;
+  padding: 10px;
   background-color: #fff;
   border-radius: 2px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, .33);
   transition: all .3s ease;
-  font-family: Helvetica, Arial, sans-serif;
 }
 
 .modal-body {
@@ -63,14 +65,14 @@ module.exports = {
   float: right;
 }
 
-/*
- * The following styles are auto-applied to elements with
- * transition="modal" when their visibility is toggled
- * by Vue.js.
- *
- * You can easily play with the modal transition by editing
- * these styles.
- */
+.modal-close {
+  float: right;
+}
+
+.modal-close-large {
+  font-size: 24px;
+  font-weight: bold;
+}
 
 .modal-enter {
   opacity: 0;

--- a/frontend/src/components/how-to-podcast-modal.vue
+++ b/frontend/src/components/how-to-podcast-modal.vue
@@ -15,7 +15,13 @@
             閉じる
           </div>
         </div>
-        </div>
+        <a href="https://itunes.apple.com/jp/podcast/%E3%81%A1%E3%82%87%E3%81%A3%E3%81%A8%E3%81%8D%E3%81%84%E3%81%A6%E5%91%89%E9%AB%98%E5%B0%82-%E5%91%89%E9%AB%98%E5%B0%82%E3%81%AE%E4%BB%8A%E3%82%92%E3%81%8A%E4%BC%9D%E3%81%88%E3%81%97%E3%81%BE%E3%81%99/id1293031618?mt=2">
+          <div class="move-podcast">
+            <p class="move-podcast-text">
+              Podcastを起動する
+            </p>
+          </div>
+        </a>
       </div>
     </div>
   </div>
@@ -30,7 +36,7 @@ module.exports = {
 <style scoped>
 .modal-mask {
   position: fixed;
-  z-index: 9998;
+  z-index: 999;
   top: 0;
   left: 0;
   width: 100%;
@@ -48,8 +54,9 @@ module.exports = {
 .modal-container {
   overflow: auto;
   width: 90%;
-  height: 100%;
-  margin: 20px auto 0 auto;
+  line-height: 20px;
+  height: 95%;
+  margin: 0 auto 0 auto;
   padding: 10px;
   background-color: #fff;
   border-radius: 2px;
@@ -61,8 +68,8 @@ module.exports = {
   margin: 20px 0;
 }
 
-.modal-default-button {
-  float: right;
+.modal-footer {
+ padding-bottom: 80px;
 }
 
 .modal-close {
@@ -86,5 +93,27 @@ module.exports = {
 .modal-leave-active .modal-container {
   -webkit-transform: scale(1.1);
   transform: scale(1.1);
+}
+
+.move-podcast {
+  position: fixed;
+  bottom: 5%;
+  left:calc(50% - 270px/2);
+  z-index: 10000;
+  background-color: #40AEC7;
+  color: #e4f5ff;
+  width: 270px;
+  margin: 0 auto;
+  font-size: 18px;
+  border-right: solid 1px #C0E4F5;
+  border-radius: 20px;
+
+  padding-left: 10px;
+  text-align: center;
+}
+
+.move-podcast-text {
+  height: 40px;
+  line-height: 40px;
 }
 </style>

--- a/frontend/src/components/how-to-podcast-modal.vue
+++ b/frontend/src/components/how-to-podcast-modal.vue
@@ -64,6 +64,13 @@ module.exports = {
   transition: all .3s ease;
 }
 
+@media only screen and (min-width: 450px) {
+  .modal-container {
+    width: 60%;
+    padding: 30px;
+  }
+}
+
 .modal-body {
   margin: 20px 0;
 }

--- a/frontend/src/components/how-to-podcast-modal.vue
+++ b/frontend/src/components/how-to-podcast-modal.vue
@@ -1,0 +1,88 @@
+<template>
+<transition name="modal">
+  <div class="modal-mask">
+    <div class="modal-wrapper">
+      <div class="modal-container">
+        <div class="modal-body">
+          <how-to-use-podcast></how-to-use-podcast>
+        </div>
+
+        <div class="modal-footer">
+          default footer
+          <button class="modal-default-button" @click="$emit('close')">
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</transition>
+</template>
+
+<script>
+module.exports = {
+}
+</script>
+
+<style scoped>
+.modal-mask {
+  position: fixed;
+  z-index: 9998;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, .7);
+  display: table;
+  transition: opacity .3s ease;
+}
+
+.modal-wrapper {
+  display: table-cell;
+  vertical-align: middle;
+}
+
+.modal-container {
+  overflow: auto;
+  width: 300px;
+  height: 100%;
+  margin: 0px auto;
+  padding: 20px 30px;
+  background-color: #fff;
+  border-radius: 2px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, .33);
+  transition: all .3s ease;
+  font-family: Helvetica, Arial, sans-serif;
+}
+
+.modal-body {
+  margin: 20px 0;
+}
+
+.modal-default-button {
+  float: right;
+}
+
+/*
+ * The following styles are auto-applied to elements with
+ * transition="modal" when their visibility is toggled
+ * by Vue.js.
+ *
+ * You can easily play with the modal transition by editing
+ * these styles.
+ */
+
+.modal-enter {
+  opacity: 0;
+}
+
+.modal-leave-active {
+  opacity: 0;
+}
+
+.modal-enter .modal-container,
+.modal-leave-active .modal-container {
+  -webkit-transform: scale(1.1);
+  transform: scale(1.1);
+}
+</style>

--- a/frontend/src/components/how-to-use-podcast.vue
+++ b/frontend/src/components/how-to-use-podcast.vue
@@ -1,0 +1,42 @@
+<template>
+<div>
+  <h2 class="ui header">Podcastの登録方法</h2>
+  <p>こんにちは！ みなさん、Podcastは使ったことがありますか？</p>
+  <p>Podcastを使うと、</p>
+  <ul>
+    <li>新しい回が追加されたらすぐに教えてくれる！</li>
+    <li>Wi-fiに繋いだときに自動でダウンロードしてくれるので聞きたいときにどこでもすぐ聞ける！</li>
+    <li>一度聞いた回は自動で削除してくれるので容量が一杯にならない！</li>
+  </ul>
+  <p>などのメリットがあります。</p>
+  <p>今回はPodcastでちょっくれを聞く方法について紹介します。</p>
+  <h2 class="ui header">iPhoneの場合</h2>
+  <p>iPhoneには標準でpodcastアプリがインストールされています。紫色のアイコンがPodcastのアプリなのでこれをタッチしてください。</p>
+  <img class="ui centered medium image" alt="Podcast登録方法説明" src="../../images/how_to_use_podcast_1.png">
+  <p>すると下のような画面が表示されます。下のバーにある「検索」をタッチしてください。</p>
+  <img class="ui centered medium image" alt="Podcast登録方法説明" src="../../images/how_to_use_podcast_2.png">
+  <p>検索バーに「ちょっときいて呉高専」と入力し検索すると番組として表示されます。表示された番組をタッチしてください。</p>
+  <img class="ui centered medium image" alt="Podcast登録方法説明" src="../../images/how_to_use_podcast_3.png">
+  <p>「購読」をタッチしてください。</p>
+  <img class="ui centered medium image" alt="Podcast登録方法説明" src="../../images/how_to_use_podcast_4.png">
+  <p>購読済みと表示されれば購読は完了です。これで下のバーの「ライブラリ」からちょっくれを聞けるようになりました！</p>
+  <img class="ui centered medium image" alt="Podcast登録方法説明" src="../../images/how_to_use_podcast_5.png">
+  <p>次に通知が送られるように設定しましょう。「設定」アプリを開いた状態から「通知」 → 「Podcast」 をタッチするとPodcastの通知設定が表示されます。画像のようにONにすれば通知設定は完了です。</p>
+  <img class="ui centered medium image" alt="Podcast登録方法説明" src="../../images/how_to_use_podcast_6.png">
+  <p>これで新しい回が追加されると通知されるようになりました！</p>
+  <h2 class="ui header">終わりに</h2>
+  <p>以上がPodcastでちょっくれを聞く方法でした。思ったより簡単だったのではないでしょうか？ 快適なちょっくれライフをお楽しみください！</p>
+</div>
+</template>
+
+<script></script>
+
+<style scoped>
+div.main > p {
+  margin-top: 16px;
+}
+
+h2.ui.header {
+  font-size: 1.28571429em;
+}
+</style>

--- a/frontend/src/packs/root.js
+++ b/frontend/src/packs/root.js
@@ -21,12 +21,14 @@ import RadioPreview from '../components/radio-preview.vue'
 import PersonalityCard from '../components/personality-card.vue'
 import PersonalitySmall from '../components/personality-small.vue'
 import PersonalityFilter from '../components/personality-filter.vue'
+import HowToPodcastLink from '../components/how-to-podcast-link.vue'
 Vue.component('app-header', Header)
 Vue.component('app-footer', Footer)
 Vue.component('radio-preview', RadioPreview)
 Vue.component('personality-card', PersonalityCard)
 Vue.component('personality-small', PersonalitySmall)
 Vue.component('personality-filter', PersonalityFilter)
+Vue.component('how-to-podcast-link', HowToPodcastLink)
 
 // Page
 import Contact from '../pages/contact.vue'

--- a/frontend/src/packs/root.js
+++ b/frontend/src/packs/root.js
@@ -21,14 +21,18 @@ import RadioPreview from '../components/radio-preview.vue'
 import PersonalityCard from '../components/personality-card.vue'
 import PersonalitySmall from '../components/personality-small.vue'
 import PersonalityFilter from '../components/personality-filter.vue'
+import HowToPodcast from '../components/how-to-use-podcast.vue'
 import HowToPodcastLink from '../components/how-to-podcast-link.vue'
+import HowToPodcastModal from '../components/how-to-podcast-modal.vue'
 Vue.component('app-header', Header)
 Vue.component('app-footer', Footer)
 Vue.component('radio-preview', RadioPreview)
 Vue.component('personality-card', PersonalityCard)
 Vue.component('personality-small', PersonalitySmall)
 Vue.component('personality-filter', PersonalityFilter)
+Vue.component('how-to-use-podcast', HowToPodcast)
 Vue.component('how-to-podcast-link', HowToPodcastLink)
+Vue.component('how-to-podcast-modal', HowToPodcastModal)
 
 // Page
 import Contact from '../pages/contact.vue'

--- a/frontend/src/pages/how-to-use-podcast.vue
+++ b/frontend/src/pages/how-to-use-podcast.vue
@@ -1,33 +1,7 @@
 <template>
-  <div class="pusher">
-    <div class="ui text container main">
-      <h2 class="ui header">Podcastの登録方法</h2>
-      <p>こんにちは！ みなさん、Podcastは使ったことがありますか？</p>
-      <p>Podcastを使うと、</p>
-      <ul>
-        <li>新しい回が追加されたらすぐに教えてくれる！</li>
-        <li>Wi-fiに繋いだときに自動でダウンロードしてくれるので聞きたいときにどこでもすぐ聞ける！</li>
-        <li>一度聞いた回は自動で削除してくれるので容量が一杯にならない！</li>
-      </ul>
-      <p>などのメリットがあります。</p>
-      <p>今回はPodcastでちょっくれを聞く方法について紹介します。</p>
-      <h2 class="ui header">iPhoneの場合</h2>
-      <p>iPhoneには標準でpodcastアプリがインストールされています。紫色のアイコンがPodcastのアプリなのでこれをタッチしてください。</p>
-      <img class="ui centered medium image" alt="Podcast登録方法説明" src="../../images/how_to_use_podcast_1.png">
-      <p>すると下のような画面が表示されます。下のバーにある「検索」をタッチしてください。</p>
-      <img class="ui centered medium image" alt="Podcast登録方法説明" src="../../images/how_to_use_podcast_2.png">
-      <p>検索バーに「ちょっときいて呉高専」と入力し検索すると番組として表示されます。表示された番組をタッチしてください。</p>
-      <img class="ui centered medium image" alt="Podcast登録方法説明" src="../../images/how_to_use_podcast_3.png">
-      <p>「購読」をタッチしてください。</p>
-      <img class="ui centered medium image" alt="Podcast登録方法説明" src="../../images/how_to_use_podcast_4.png">
-      <p>購読済みと表示されれば購読は完了です。これで下のバーの「ライブラリ」からちょっくれを聞けるようになりました！</p>
-      <img class="ui centered medium image" alt="Podcast登録方法説明" src="../../images/how_to_use_podcast_5.png">
-      <p>次に通知が送られるように設定しましょう。「設定」アプリを開いた状態から「通知」 → 「Podcast」 をタッチするとPodcastの通知設定が表示されます。画像のようにONにすれば通知設定は完了です。</p>
-      <img class="ui centered medium image" alt="Podcast登録方法説明" src="../../images/how_to_use_podcast_6.png">
-      <p>これで新しい回が追加されると通知されるようになりました！</p>
-      <h2 class="ui header">終わりに</h2>
-      <p>以上がPodcastでちょっくれを聞く方法でした。思ったより簡単だったのではないでしょうか？ 快適なちょっくれライフをお楽しみください！</p>
-    </div>
+<div class="pusher">
+  <div class="ui text container main">
+    <how-to-use-podcast></how-to-use-podcast>
   </div>
 </div>
 </template>
@@ -35,14 +9,6 @@
 <script></script>
 
 <style scoped>
-div.main > p {
-  margin-top: 16px;
-}
-
-h2.ui.header {
-  font-size: 1.28571429em;
-}
-
 .main {
   padding-top: 80px;
   padding-bottom: 40px;

--- a/frontend/src/pages/top.vue
+++ b/frontend/src/pages/top.vue
@@ -23,6 +23,7 @@
           </radio-preview>
         </div>
       </transition-group>
+      <how-to-podcast-link></how-to-podcast-link>
     </div>
   </div>
 </template>

--- a/frontend/src/pages/top.vue
+++ b/frontend/src/pages/top.vue
@@ -23,8 +23,8 @@
           </radio-preview>
         </div>
       </transition-group>
-      <how-to-podcast-link></how-to-podcast-link>
     </div>
+    <how-to-podcast-link></how-to-podcast-link>
   </div>
 </template>
 


### PR DESCRIPTION
closed #163 

# やったこと
* トップページはpodcastの登録方法へのリンクがずっと表示されるようにした
* 登録方法をmodalとして表示
* 登録方法からpodcastを開けるようにした(ios, macのみ？)

# やってないこと
* 登録方法の内容推敲 → 縦で見ると長いかも

![1 -23-2018 17-11-21](https://user-images.githubusercontent.com/13253769/35264552-872e04f6-0060-11e8-95f6-d036e2478cd4.gif)
![1 -23-2018 17-14-59](https://user-images.githubusercontent.com/13253769/35264714-1e7b0e58-0061-11e8-9f55-d974fe7ce498.gif)
