### PR TITLE
podcast登録画面の調整

### DIFF
--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -16,6 +16,7 @@
 #body {
   display: flex;
   flex-direction: column;
+  -webkit-overflow-scrolling: touch;
 }
 
 #wrapper {

--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -1,8 +1,8 @@
 <template>
-  <div id="body">
-    <div id="wrapper">
+  <div class="body">
+    <div class="wrapper">
       <app-header></app-header>
-      <main id="main">
+      <main class="main">
       <router-view></router-view>
       </main>
       <app-footer></app-footer>
@@ -13,19 +13,19 @@
 <script></script>
 
 <style>
-#body {
+.body {
   display: flex;
   flex-direction: column;
   -webkit-overflow-scrolling: touch;
 }
 
-#wrapper {
+.wrapper {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
 }
 
-#main {
+.main {
   flex: 1 1 auto;
 }
 </style>

--- a/frontend/src/components/how-to-podcast-modal.vue
+++ b/frontend/src/components/how-to-podcast-modal.vue
@@ -53,12 +53,12 @@ module.exports = {
 
 .modal-container {
   overflow: auto;
-  width: 80%;
+  width: 90%;
   line-height: 20px;
-  height: 95%;
+  height: 80%;
   margin: 0 auto 0 auto;
   padding: 10px;
-  padding-bottom: 110px;
+  padding-bottom: 80px;
   background-color: #fff;
   border-radius: 2px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, .33);
@@ -107,7 +107,7 @@ module.exports = {
 .move-podcast {
   position: fixed;
   -webkit-overflow-scrolling: auto;
-  bottom: 5%;
+  bottom: 8%;
   left:calc(50% - 270px/2);
   z-index: 10000;
   background-color: #40AEC7;

--- a/frontend/src/components/how-to-podcast-modal.vue
+++ b/frontend/src/components/how-to-podcast-modal.vue
@@ -69,6 +69,7 @@ module.exports = {
   .modal-container {
     width: 60%;
     padding: 30px;
+    padding-bottom: 150px;
   }
 }
 

--- a/frontend/src/components/how-to-podcast-modal.vue
+++ b/frontend/src/components/how-to-podcast-modal.vue
@@ -1,7 +1,7 @@
 <template>
 <transition name="modal">
   <div class="modal-mask">
-    <div class="modal-wrapper">
+    <div class="modal-wrapper" @click.self="$emit('close')">
       <div class="modal-container">
         <div class="modal-close" @click="$emit('close')">
           <span class="modal-close-large">×</span>

--- a/frontend/src/components/how-to-podcast-modal.vue
+++ b/frontend/src/components/how-to-podcast-modal.vue
@@ -40,7 +40,7 @@ module.exports = {
   top: 0;
   left: 0;
   width: 100%;
-  height: 100%;
+  height: 120%;
   background-color: rgba(0, 0, 0, .7);
   display: table;
   transition: opacity .3s ease;
@@ -53,11 +53,12 @@ module.exports = {
 
 .modal-container {
   overflow: auto;
-  width: 90%;
+  width: 80%;
   line-height: 20px;
   height: 95%;
   margin: 0 auto 0 auto;
   padding: 10px;
+  padding-bottom: 110px;
   background-color: #fff;
   border-radius: 2px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, .33);

--- a/frontend/src/components/how-to-podcast-modal.vue
+++ b/frontend/src/components/how-to-podcast-modal.vue
@@ -48,7 +48,7 @@ module.exports = {
 
 .modal-wrapper {
   display: table-cell;
-  vertical-align: middle;
+  vertical-align: top;
 }
 
 .modal-container {
@@ -56,9 +56,8 @@ module.exports = {
   width: 90%;
   line-height: 20px;
   height: 80%;
-  margin: 0 auto 0 auto;
+  margin: 20px auto 0 auto;
   padding: 10px;
-  padding-bottom: 80px;
   background-color: #fff;
   border-radius: 2px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, .33);
@@ -69,7 +68,7 @@ module.exports = {
   .modal-container {
     width: 60%;
     padding: 30px;
-    padding-bottom: 150px;
+    padding-bottom: 0;
   }
 }
 

--- a/frontend/src/components/how-to-podcast-modal.vue
+++ b/frontend/src/components/how-to-podcast-modal.vue
@@ -72,6 +72,16 @@ module.exports = {
   }
 }
 
+@media only screen and (device-width : 375px) and (device-height : 812px) and (-webkit-device-pixel-ratio : 3) {
+  .modal-mask {
+    height: 140%;
+  }
+
+  .modal-container {
+    height: 68%;
+  }
+}
+
 .modal-body {
   margin: 20px 0;
 }

--- a/frontend/src/components/how-to-podcast-modal.vue
+++ b/frontend/src/components/how-to-podcast-modal.vue
@@ -104,6 +104,7 @@ module.exports = {
 
 .move-podcast {
   position: fixed;
+  -webkit-overflow-scrolling: auto;
   bottom: 5%;
   left:calc(50% - 270px/2);
   z-index: 10000;


### PR DESCRIPTION
closed #214 
closed #215 

# やったこと
* iPhoneでのスクロールのカクつきを修正
* iPhoneでスクロールしすぎるとグレーが取れてしまう問題を修正
* グレーをクリックで閉じるように変更

# やってないこと
* Podcastを起動するがスクロールに合わせてプルプルしてしまうようになった