### PR TITLE
adminのnavbarの修正

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -16,11 +16,11 @@
 
 <body class="fixed-nav bg-dark">
 
-<nav class="row navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
+<nav class="row navbar navbar-expand-lg navbar-dark bg-dark fixed-top" id="mainNav">
   <div class="col-3">
     <%= link_to "[ADMIN]ちょっときいて呉高専", admin_root_path, class: "navbar-brand" %>
   </div>
-  <div class="offset-md-6 col-3">
+  <div class="col-9 text-right">
     <span class="navbar-text"><%= current_personality.name %>(<%= current_personality.role.t %>)</span>
     <%= link_to "ログアウト", destroy_personality_session_path(current_personality), method: :delete, data: { confirm: "ログアウトしてもいいですか？" }, class: "btn btn-light btn-sm" %>
   </div>
@@ -39,3 +39,4 @@
 </div>
 </body>
 </html>
+


### PR DESCRIPTION
closed #237 

# やったこと
- [x] navタグに`bg-dark`を追加
- [x] ログアウトのdivタグのクラスを右寄せにした

# やってないこと
- [ ] mobileの対応
<details><summary>iPhone 7 Google Chrome</summary>

![img_5352](https://user-images.githubusercontent.com/31001505/37106819-14d10d1c-2276-11e8-9988-61e67324ab39.PNG)

</details>

# スクリーンショット
<details><summary>PC Windows 10</summary>

![after_pc](https://user-images.githubusercontent.com/31001505/37106729-e840b860-2275-11e8-8b22-bb2882d9c75a.PNG)

</details>

<details><summary>iPhone 7 Google Chrome</summary>

![img_5352](https://user-images.githubusercontent.com/31001505/37106819-14d10d1c-2276-11e8-9988-61e67324ab39.PNG)

</details>