### PR TITLE
fix personality policy

### DIFF
--- a/app/policies/admin/personality_policy.rb
+++ b/app/policies/admin/personality_policy.rb
@@ -18,6 +18,13 @@ class Admin::PersonalityPolicy < Admin::BasePolicy
     false
   end
 
+  def destroy?
+    # 自分自身のユーザー情報は削除できない
+    return false if personality == record
+    return true if personality.admin? || personality.secret?
+    false
+  end
+
   def change_role_to_guest?
     return true if personality.allow_change_role?
     false


### PR DESCRIPTION
# やったこと
admin/secret/editorはパーソナリティを誰でも削除できる
↓
admin/secretは自分以外のパーソナリティを削除できる

に変更しました。

* editorにも削除権限はあったのは単純にミスだったので修正しました。
(editorは自身とguestのみのパーソナリティしか更新できないとなっているよりよりクリティカルな削除機能の方が制限が緩かったので)

* ログイン中のパーソナリティが自分を削除するのは危ない香りがしたので自分自身は削除できないように変更しました。


# やってないこと
特になし。
