### PR TITLE
ラジオ/パーソナリティ詳細画面から、別のラジオ/パーソナリティの詳細画面へのリンクを踏んだときに画面がリロードされない問題を修正

### DIFF
--- a/frontend/src/app.vue
+++ b/frontend/src/app.vue
@@ -3,7 +3,7 @@
     <div class="wrapper">
       <app-header></app-header>
       <main class="main">
-      <router-view></router-view>
+      <router-view :key="$route.fullPath"></router-view>
       </main>
       <app-footer></app-footer>
     </div>


### PR DESCRIPTION
closed #189

# やったこと
- ラジオ/パーソナリティ詳細画面から、別のラジオ/パーソナリティの詳細画面へのリンクを踏んだときに画面がリロードされない問題を修正

# やってないこと
なし
