### PR TITLE
Attach preload='metadata' to audio tag

### DIFF
--- a/app/views/admin/radios/show.html.erb
+++ b/app/views/admin/radios/show.html.erb
@@ -24,12 +24,12 @@
 
 <dl class="dl-horizontal">
   <dt><strong><%= Radio.human_attribute_name('mp3') %> :</strong></dt>
-  <dd><%= audio_tag(@radio.mp3_url, controls: true) %></dd>
+  <dd><%= audio_tag(@radio.mp3_url, controls: true, preload: "metadata") %></dd>
 </dl>
 
 <dl class="dl-horizontal">
   <dt><strong><%= Radio.human_attribute_name('digest_mp3') %> :</strong></dt>
-  <dd><%= audio_tag(@radio.digest_mp3_url, controls: true) if @radio.digest_mp3_url %></dd>
+  <dd><%= audio_tag(@radio.digest_mp3_url, controls: true, preload: "metadata") if @radio.digest_mp3_url %></dd>
 </dl>
 
 <dl class="dl-horizontal">

--- a/frontend/src/components/radio-preview.vue
+++ b/frontend/src/components/radio-preview.vue
@@ -16,13 +16,13 @@
       <div class="mp3" v-if="digestMp3Url">
         <div class="ui label">
           <p>ダイジェスト版:</p>
-          <audio controls="controls" v-bind:src="digestMp3Url"></audio>
+          <audio controls="controls" v-bind:src="digestMp3Url" preload="metadata"></audio>
         </div>
       </div>
       <div class="mp3">
         <div class="ui label">
           <p>本編はこちら！</p>
-          <audio controls="controls" v-bind:src="mp3Url"></audio>
+          <audio controls="controls" v-bind:src="mp3Url" preload="metadata"></audio>
         </div>
       </div>
       <div class="meta">


### PR DESCRIPTION
# やったこと
audio tagに`preload=metadata`を追加しました。
https://developer.mozilla.org/ja/docs/Web/HTML/Element/audio

これをすることにより再生ボタンを押さないとloadingがされなくなります。
今サーバー代で一番高かったのはサーバーからのデータダウンロードだったのでこれでだいぶ安くなる気がする。

# やってないこと
特になし。
