### PR TITLE
Rename slack channel

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -83,7 +83,7 @@ namespace :deploy do
       execute <<-COMMAND
         curl -X POST --data-urlencode \
           \"payload={ \
-            \\\"channel\\\": \\\"#team-web\\\", \
+            \\\"channel\\\": \\\"#team-web_ウェブ開発\\\", \
             \\\"username\\\": \\\"onigiri\\\", \
             \\\"text\\\": \\\"#{fetch(:branch)}ブランチの#{fetch(:rails_env)}へのデプロイを完了したよ！\\\", \
             \\\"icon_emoji\\\": \\\":onigirikun:\\\"\


### PR DESCRIPTION
# WHY
#268 の修正をもう一度しなければならなくなったため

# WHAT
## やったこと
- rename posted slack channel `#team-web` to `#team-web_ウェブ開発`

## やってないこと
- 特になし
