### PR TITLE
Modify preload=metadata -> preload=none

### DIFF
--- a/app/models/radio.rb
+++ b/app/models/radio.rb
@@ -68,4 +68,8 @@ class Radio < ApplicationRecord
   def draft?
     published_at.nil?
   end
+
+  def play_time
+    Time.at(duration).utc.strftime((duration < 3600) ? "%-M:%S" : "%-H:%M:%S")
+  end
 end

--- a/app/serializers/radio_serializer.rb
+++ b/app/serializers/radio_serializer.rb
@@ -22,7 +22,7 @@
 #
 
 class RadioSerializer < ActiveModel::Serializer
-  attributes :id, :title, :description, :mp3, :digest_mp3, :youtube_url, :podcast_url, :image, :duration, :published_at, :created_at, :updated_at
+  attributes :id, :title, :description, :mp3, :digest_mp3, :youtube_url, :podcast_url, :image, :play_time, :published_at, :created_at, :updated_at
 
   has_many :personalities
 

--- a/app/services/podcast/feed.rb
+++ b/app/services/podcast/feed.rb
@@ -55,15 +55,11 @@ module Podcast
           item.link             = join_radio_link(radio)
           item.description      = MarkdownHelper.markdown(radio.description)
           item.pubDate          = radio.published_at.to_s(:rfc822)
-          item.itunes_duration  = format_duration(radio.duration)
+          item.itunes_duration  = radio.play_time
           item.enclosure.url    = transform_to_blubrry(fullpath_to_url(radio.mp3_url))
           item.enclosure.type   = "audio/mpeg"
           item.enclosure.length = radio.size
         end
-      end
-
-      def format_duration(sec)
-        Time.at(sec).utc.strftime((sec < 3600) ? "%-M:%S" : "%-H:%M:%S")
       end
 
       def join_radio_link(radio)

--- a/frontend/src/components/radio-preview.vue
+++ b/frontend/src/components/radio-preview.vue
@@ -21,8 +21,8 @@
       </div>
       <div class="mp3">
         <div class="ui label">
-          <p>本編はこちら！</p>
-          <audio controls="controls" v-bind:src="mp3Url" preload="metadata"></audio>
+          <p>本編はこちら！({{ playTime }})</p>
+          <audio controls="controls" v-bind:src="mp3Url" preload="none"></audio>
         </div>
       </div>
       <div class="meta">
@@ -78,8 +78,13 @@ module.exports = {
     },
     date: {
       type: String,
-      default: '2017/12/03 1:08',
-      required: true
+      default: "2017/12/03 1:08",
+      required: true,
+    },
+    playTime: {
+      type: String,
+      default: "--:--",
+      required: true,
     },
   }
 }

--- a/frontend/src/pages/top.vue
+++ b/frontend/src/pages/top.vue
@@ -20,7 +20,8 @@
              :personalities="radio.personalities"
              :mp3-url="radio.mp3.url"
              :digest-mp3-url="radio.digest_mp3.url"
-             :date="radio.published_at">
+             :date="radio.published_at"
+             :play-time="radio.play_time">
           </radio-preview>
       </transition-group>
     </div>

--- a/spec/models/radio_spec.rb
+++ b/spec/models/radio_spec.rb
@@ -95,4 +95,25 @@ RSpec.describe Radio, type: :model do
       it { is_expected.to be false }
     end
   end
+
+  describe "#play_time" do
+    before do
+      allow_any_instance_of(Radio).to receive(:extract_meta_mp3).and_return(nil)
+    end
+
+    context "under 1 minute" do
+      it { expect(create(:radio, size: 1000, duration: 3).play_time).to eq "0:03" }
+      it { expect(create(:radio, size: 1000, duration: 20).play_time).to eq "0:20" }
+    end
+
+    context "under 1 hour" do
+      it { expect(create(:radio, size: 1000, duration: 300).play_time).to eq "5:00" }
+      it { expect(create(:radio, size: 1000, duration: 1000).play_time).to eq "16:40" }
+    end
+
+    context "over 1 hour" do
+      it { expect(create(:radio, size: 1000, duration: 3600).play_time).to eq "1:00:00" }
+      it { expect(create(:radio, size: 1000, duration: 4000).play_time).to eq "1:06:40" }
+    end
+  end
 end

--- a/spec/models/radio_spec.rb
+++ b/spec/models/radio_spec.rb
@@ -97,23 +97,27 @@ RSpec.describe Radio, type: :model do
   end
 
   describe "#play_time" do
-    before do
-      allow_any_instance_of(Radio).to receive(:extract_meta_mp3).and_return(nil)
+    let(:radio) { create(:radio) }
+
+    it "returns 0:XX when under 1 minute" do
+      radio.duration = 3
+      expect(radio.play_time).to eq "0:03"
+      radio.duration = 20
+      expect(radio.play_time).to eq "0:20" 
     end
 
-    context "under 1 minute" do
-      it { expect(create(:radio, size: 1000, duration: 3).play_time).to eq "0:03" }
-      it { expect(create(:radio, size: 1000, duration: 20).play_time).to eq "0:20" }
+    it "returns XX:XX when under 1 hour" do
+      radio.duration = 300
+      expect(radio.play_time).to eq "5:00"
+      radio.duration = 1000
+      expect(radio.play_time).to eq "16:40" 
     end
 
-    context "under 1 hour" do
-      it { expect(create(:radio, size: 1000, duration: 300).play_time).to eq "5:00" }
-      it { expect(create(:radio, size: 1000, duration: 1000).play_time).to eq "16:40" }
-    end
-
-    context "over 1 hour" do
-      it { expect(create(:radio, size: 1000, duration: 3600).play_time).to eq "1:00:00" }
-      it { expect(create(:radio, size: 1000, duration: 4000).play_time).to eq "1:06:40" }
+    it "returns XX:XX:XX when over 1 hour" do
+      radio.duration = 3600
+      expect(radio.play_time).to eq "1:00:00"
+      radio.duration = 4000
+      expect(radio.play_time).to eq "1:06:40" 
     end
   end
 end

--- a/spec/models/radio_spec.rb
+++ b/spec/models/radio_spec.rb
@@ -103,21 +103,21 @@ RSpec.describe Radio, type: :model do
       radio.duration = 3
       expect(radio.play_time).to eq "0:03"
       radio.duration = 20
-      expect(radio.play_time).to eq "0:20" 
+      expect(radio.play_time).to eq "0:20"
     end
 
     it "returns XX:XX when under 1 hour" do
       radio.duration = 300
       expect(radio.play_time).to eq "5:00"
       radio.duration = 1000
-      expect(radio.play_time).to eq "16:40" 
+      expect(radio.play_time).to eq "16:40"
     end
 
     it "returns XX:XX:XX when over 1 hour" do
       radio.duration = 3600
       expect(radio.play_time).to eq "1:00:00"
       radio.duration = 4000
-      expect(radio.play_time).to eq "1:06:40" 
+      expect(radio.play_time).to eq "1:06:40"
     end
   end
 end


### PR DESCRIPTION
closed #277 

# WHY
AWSの請求金額の9割をS3のデータ転送量が占めている。
S3に上げているファイルは画像と音声ファイルがあり、音声ファイルの方が圧倒的にサイズが大きいので確実に音声ファイルが原因。

一番問題だったのがトップページにアクセスしたときのロードで、表示されてる分全てをロードしていたので40MBxラジオ20回分で800MB!!!もロードされていた。

これは #266 で対応していて、でpreload=metadataにすればラジオ1回あたり数十KBに抑えられるようになったので問題は解決したと思われていた。

が、全然請求金額が下がらなかったので色々調べていると「S3はHTTP status 206(partial content)でアクセスしても元々のデータサイズ分の請求がくるよ」との記事を見つけて愕然とした。。。
https://forums.aws.amazon.com/thread.jspa?threadID=54214

# WHAT
## やったこと
Podcast用にDBに保存していた再生時間を表示させ、audioタグのpreload属性はmetadataからnoneに変更しクリックしないとデータを取得しないように変更しました。


## やってないこと
ダイジェスト版は今まで通りmetadataを取得するようにしています。
理由はダイジェスト版はあまり音声ファイルが大きくなく数も少ないので問題にはならないだろうと判断しました。

|before|after|
|---|---|
|![screen shot 2018-04-28 at 11 37 36](https://user-images.githubusercontent.com/13253769/39391080-198ff4c2-4ad9-11e8-9860-a0cc3ad855ec.png)|![screen shot 2018-04-28 at 11 37 28](https://user-images.githubusercontent.com/13253769/39391083-233d12a2-4ad9-11e8-91b0-25f84fe8dfa0.png)|
|![screen shot 2018-04-28 at 11 39 13](https://user-images.githubusercontent.com/13253769/39391086-2e01ad92-4ad9-11e8-84d0-c680954cbd5d.png)|<img width="620" alt="screen shot 2018-04-28 at 11 39 28" src="https://user-images.githubusercontent.com/13253769/39391091-3ce076d6-4ad9-11e8-9cf8-5ea95d90b55f.png">|
