### PR TITLE
Add sns id to personalities

### DIFF
--- a/app/controllers/admin/personalities_controller.rb
+++ b/app/controllers/admin/personalities_controller.rb
@@ -98,7 +98,7 @@ class Admin::PersonalitiesController < Admin::BaseController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def personality_params
-      params.require(:personality).permit(:name, :nickname, :image, :description, :tag_list)
+      params.require(:personality).permit(:name, :nickname, :image, :description, :tag_list, :twitter_id, :facebook_id, :instagram_id)
     end
 
     def provisional_personality_params

--- a/app/models/personality.rb
+++ b/app/models/personality.rb
@@ -20,6 +20,9 @@
 #  role                   :integer          default(0), not null
 #  image                  :string(255)
 #  nickname               :string(255)
+#  twitter_id             :string(255)
+#  facebook_id            :string(255)
+#  instagram_id           :string(255)
 #
 # Indexes
 #

--- a/app/serializers/personality_serializer.rb
+++ b/app/serializers/personality_serializer.rb
@@ -20,6 +20,9 @@
 #  role                   :integer          default(0), not null
 #  image                  :string(255)
 #  nickname               :string(255)
+#  twitter_id             :string(255)
+#  facebook_id            :string(255)
+#  instagram_id           :string(255)
 #
 # Indexes
 #

--- a/app/serializers/personality_serializer.rb
+++ b/app/serializers/personality_serializer.rb
@@ -31,7 +31,7 @@
 #
 
 class PersonalitySerializer < ActiveModel::Serializer
-  attributes :id, :name, :nickname, :description, :role, :image, :tag_list
+  attributes :id, :name, :nickname, :description, :role, :image, :tag_list, :twitter_id, :facebook_id, :instagram_id
 
   has_many :radios
 

--- a/app/views/admin/personalities/_form.html.erb
+++ b/app/views/admin/personalities/_form.html.erb
@@ -44,6 +44,36 @@
     </div>
   </div>
 
+  <div class="form-group row">
+    <%= form.label :twitter_id, class: 'col-2 col-form-label' %>
+    <div class="col-10">
+      <div class="input-group">
+        <div class="input-group-addon">@</div>
+        <%= form.text_field :twitter_id, class: 'form-control' %>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group row">
+    <%= form.label :instagram_id, class: 'col-2 col-form-label' %>
+    <div class="col-10">
+      <div class="input-group">
+        <div class="input-group-addon">@</div>
+        <%= form.text_field :instagram_id, class: 'form-control' %>
+      </div>
+    </div>
+  </div>
+
+  <div class="form-group row">
+    <%= form.label :facebook_id, class: 'col-2 col-form-label' %>
+    <div class="col-10">
+      <div class="input-group">
+        <div class="input-group-addon">https://www.facebook.com/</div>
+        <%= form.text_field :facebook_id, class: 'form-control' %>
+      </div>
+    </div>
+  </div>
+
   <div class="actions">
     <%= form.submit class: 'btn btn-primary' %>
   </div>

--- a/app/views/admin/personalities/show.html.erb
+++ b/app/views/admin/personalities/show.html.erb
@@ -45,6 +45,21 @@
 </dl>
 
 <dl class="dl-horizontal">
+  <dt><strong><%= Personality.human_attribute_name('twitter_id') %> :</strong></dt>
+  <dd><%= link_to @personality.twitter_id, "https://twitter.com/#{@personality.twitter_id}" %></dd>
+</dl>
+
+<dl class="dl-horizontal">
+  <dt><strong><%= Personality.human_attribute_name('facebook_id') %> :</strong></dt>
+  <dd><%= link_to @personality.facebook_id, "https://www.facebook.com/#{@personality.facebook_id}" %></dd>
+</dl>
+
+<dl class="dl-horizontal">
+  <dt><strong><%= Personality.human_attribute_name('instagram_id') %> :</strong></dt>
+  <dd><%= link_to @personality.instagram_id, "https://www.instagram.com/#{@personality.instagram_id}" %></dd>
+</dl>
+
+<dl class="dl-horizontal">
   <dt><strong><%= Personality.human_attribute_name('radios') %> :</strong></dt>
   <dd>
     <% @personality.radios.each do |radio| %>

--- a/config/locales/models/personality.ja.yml
+++ b/config/locales/models/personality.ja.yml
@@ -13,3 +13,6 @@ ja:
         password: パスワード
         radios: 収録した回
         tag_list: タグ
+        twitter_id: Twitter ID
+        facebook_id: facebook ID
+        instagram_id: Instagram ID

--- a/config/locales/models/personality.ja.yml
+++ b/config/locales/models/personality.ja.yml
@@ -14,5 +14,5 @@ ja:
         radios: 収録した回
         tag_list: タグ
         twitter_id: Twitter ID
-        facebook_id: facebook ID
+        facebook_id: Facebook ID
         instagram_id: Instagram ID

--- a/db/migrate/20190601164015_add_sns_to_personalities.rb
+++ b/db/migrate/20190601164015_add_sns_to_personalities.rb
@@ -1,0 +1,7 @@
+class AddSnsToPersonalities < ActiveRecord::Migration[5.1]
+  def change
+    add_column :personalities, :twitter_id, :string
+    add_column :personalities, :facebook_id, :string
+    add_column :personalities, :instagram_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180126145434) do
+ActiveRecord::Schema.define(version: 20190601164015) do
 
   create_table "communities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string "name", null: false
@@ -90,6 +90,9 @@ ActiveRecord::Schema.define(version: 20180126145434) do
     t.integer "role", default: 0, null: false
     t.string "image"
     t.string "nickname"
+    t.string "twitter_id"
+    t.string "facebook_id"
+    t.string "instagram_id"
     t.index ["email"], name: "index_personalities_on_email", unique: true
     t.index ["reset_password_token"], name: "index_personalities_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
# WHY

#333 
新デザインではパーソナリティとSNSのidを紐づけられるようになっている
(SNS連携してログインできるわけではない)

# WHAT
## やったこと

- twitter, facebook, instagramのidをパーソナリティごとで保存できるようにした

## やってないこと

- 追加しただけなので特にないはず？

<img width="1127" alt="Screen Shot 2019-06-02 at 2 47 12" src="https://user-images.githubusercontent.com/13253769/58751951-5d56fa00-84e1-11e9-9504-ac18dcbab476.png">
