### PR TITLE
mobx-react-liteへ置き換える

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,6 @@
   "dependencies": {
     "axios": "0.19.0-beta.1",
     "mobx": "^5.9.4",
-    "mobx-react": "^5.4.4",
     "mobx-react-lite": "^1.3.2",
     "normalize.css": "^8.0.0",
     "react": "^16.8.6",

--- a/frontend/src/components/App/index.tsx
+++ b/frontend/src/components/App/index.tsx
@@ -1,13 +1,17 @@
 import React from "react";
 
+import RootStore from "@/stores/RootStore";
+import { Provider } from "@/utils/Contexts/RootContext";
+
 import Header from "@/layouts/Header";
 import Main from "@/layouts/Main";
 import Footer from "@/layouts/Footer";
 
+// TODO(euglena1215): URLのproductionとの切り替え方法を考える
 export default () => (
-  <>
+  <Provider value={new RootStore("http://localhost:3000")}>
     <Header />
     <Main />
     <Footer />
-  </>
+  </Provider>
 );

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -3,21 +3,16 @@ import "normalize.css";
 import React from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter } from "react-router-dom";
-import { Provider } from "mobx-react";
 import GlobalStyle from "@/constants/styles/global";
 
 import App from "@/components/App";
-import RootStore from "@/stores/RootStore";
 
-// TODO(euglena1215): URLのproductionとの切り替え方法を考える
 ReactDOM.render(
-  <Provider rootStore={new RootStore("http://localhost:3000")}>
-    <BrowserRouter basename="/app">
-      <>
-        <App />
-        <GlobalStyle />
-      </>
-    </BrowserRouter>
-  </Provider>,
+  <BrowserRouter basename="/app">
+    <>
+      <App />
+      <GlobalStyle />
+    </>
+  </BrowserRouter>,
   document.getElementById("app")
 );

--- a/frontend/src/layouts/Main.tsx
+++ b/frontend/src/layouts/Main.tsx
@@ -1,20 +1,32 @@
 import React from "react";
 import { Switch, Route } from "react-router-dom";
 
+import RootContext from "@/utils/Contexts/RootContext";
+
 import Index from "@/pages/Index";
 import RadioHistory from "@/pages/RadioHistory";
 import Contact from "@/pages/Contact";
 import Blog from "@/pages/Blog";
 import Personality from "@/pages/Personality";
 
-export default () => (
-  <main>
-    <Switch>
-      <Route exact path="/" component={Index} />
-      <Route path="/radios" component={RadioHistory} />
-      <Route path="/contact" component={Contact} />
-      <Route path="/blog" component={Blog} />
-      <Route path="/personality" component={Personality} />
-    </Switch>
-  </main>
-);
+export default () => {
+  const rootStore = React.useContext(RootContext);
+
+  return (
+    <main>
+      <Switch>
+        <Route exact path="/" component={Index} />
+        <Route
+          path="/radios"
+          render={() => <RadioHistory rootStore={rootStore} />}
+        />
+        <Route
+          path="/contact"
+          render={() => <Contact rootStore={rootStore} />}
+        />
+        <Route path="/blog" component={Blog} />
+        <Route path="/personality" component={Personality} />
+      </Switch>
+    </main>
+  );
+};

--- a/frontend/src/pages/Contact.tsx
+++ b/frontend/src/pages/Contact.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "styled-components";
+import { observer } from "mobx-react-lite";
 import { withRouter, RouteComponentProps } from "react-router-dom";
-import { inject } from "mobx-react";
 
 import RootStore from "@/stores/RootStore";
 
@@ -10,81 +10,63 @@ import { color, device } from "@/constants/styles";
 import HeroArea from "@/components/atoms/HeroArea";
 import ContactForm from "@/components/molecules/Contact/Form";
 
-interface IProp {
+interface IProps {
   rootStore?: RootStore;
 }
 
-interface IState {
-  alert: {
-    message: string;
-    status?: string;
+interface IAlert {
+  message: string;
+  status?: string;
+}
+
+const Contact = observer((props: IProps & RouteComponentProps) => {
+  const [alert, setAlert] = React.useState<IAlert>({
+    message: "",
+    status: undefined
+  });
+
+  const rootStore = props.rootStore!;
+
+  const successSendContact = () => {
+    setAlert({
+      status: "successed",
+      message: "おたよりを送信しました。 5秒後に自動でトップページに戻ります。"
+    });
+    setTimeout(() => props.history.push("/"), 5000);
   };
-}
 
-@inject("rootStore")
-class Contact extends React.Component<IProp & RouteComponentProps, IState> {
-  constructor(props: any) {
-    super(props);
-    this.state = {
-      alert: {
-        message: "",
-        status: undefined
-      }
-    };
-
-    this.successSendContact = this.successSendContact.bind(this);
-    this.failSendContact = this.failSendContact.bind(this);
-  }
-
-  public render() {
-    const rootStore = this.props.rootStore!;
-
-    return (
-      <div>
-        <HeroArea>
-          <HeroContentWrapper>
-            Contact
-            <HeroContentBar />
-            ご意見ご感想お待ちしております
-          </HeroContentWrapper>
-        </HeroArea>
-        <ContactFormWrapper>
-          <div>
-            <ContactFormTitle>お問い合わせフォーム</ContactFormTitle>
-
-            <ContactForm
-              contactStore={rootStore.contactStore}
-              successed={this.successSendContact}
-              failed={this.failSendContact}
-              alert={this.state.alert}
-            />
-          </div>
-        </ContactFormWrapper>
-      </div>
-    );
-  }
-
-  public successSendContact(_: object) {
-    this.setState({
-      alert: {
-        status: "successed",
-        message:
-          "おたよりを送信しました。 5秒後に自動でトップページに戻ります。"
-      }
+  const failSendContact = () => {
+    setAlert({
+      status: "failed",
+      message:
+        "おたよりの送信に失敗しました。 * がついている項目は全て記入して再送信してください。"
     });
-    setTimeout(() => console.log(this.props.history.push("/")), 5000);
-  }
+  };
 
-  public failSendContact(_: object) {
-    this.setState({
-      alert: {
-        status: "failed",
-        message:
-          "おたよりの送信に失敗しました。 * がついている項目は全て記入して再送信してください。"
-      }
-    });
-  }
-}
+  return (
+    <div>
+      <HeroArea>
+        <HeroContentWrapper>
+          Contact
+          <HeroContentBar />
+          ご意見ご感想お待ちしております
+        </HeroContentWrapper>
+      </HeroArea>
+      <ContactFormWrapper>
+        <div>
+          <ContactFormTitle>お問い合わせフォーム</ContactFormTitle>
+
+          <ContactForm
+            contactStore={rootStore.contactStore}
+            successed={successSendContact}
+            failed={failSendContact}
+            alert={alert}
+          />
+        </div>
+      </ContactFormWrapper>
+    </div>
+  );
+});
 
 const ContactFormWrapper = styled.div`
   width: 100%;

--- a/frontend/src/utils/Contexts/RootContext.ts
+++ b/frontend/src/utils/Contexts/RootContext.ts
@@ -1,0 +1,8 @@
+import React from "react";
+
+import RootStore from "@/stores/RootStore";
+
+const RootContext = React.createContext({} as RootStore);
+
+export const { Provider } = RootContext;
+export default RootContext;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1840,7 +1840,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0:
+hoist-non-react-statics@^3.1.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
   dependencies:
@@ -2565,13 +2565,6 @@ mobx-react-lite@^1.3.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-1.4.0.tgz#193beb5fdddf17ae61542f65ff951d84db402351"
 
-mobx-react@^5.4.4:
-  version "5.4.4"
-  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-5.4.4.tgz#b3de9c6eabcd0ed8a40036888cb0221ab9568b80"
-  dependencies:
-    hoist-non-react-statics "^3.0.0"
-    react-lifecycles-compat "^3.0.2"
-
 mobx@^5.9.4:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/mobx/-/mobx-5.10.0.tgz#6107a73a27aee72abdc977ab75f9ec0d0983aa61"
@@ -3219,10 +3212,6 @@ react-dom@^16.8.6:
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
-
-react-lifecycles-compat@^3.0.2:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
 
 react-router-dom@^5.0.0:
   version "5.0.1"


### PR DESCRIPTION
#371 マージ後

# WHY
`mobx-react`と`mobx-react-lite`が混在しているので、`mobx-react`を抜く

# WHAT
## やったこと

- [x] `RootContext`を作って`rootStore`を流すようにした
- [x] `Contact`ページをクラスコンポーネントからHooksに書き換えた
