### PR TITLE
add window-events hooks

### DIFF
--- a/frontend/src/utils/hooks/window-events.ts
+++ b/frontend/src/utils/hooks/window-events.ts
@@ -1,0 +1,15 @@
+import React from "react";
+
+type Callback = () => void;
+
+const useWindowEvent = (callback: Callback, target: string): void => {
+  React.useEffect(() => {
+    window.addEventListener(target, callback);
+    return () => {
+      window.removeEventListener(target, callback);
+    };
+  }, [callback]);
+};
+
+export const useResizeEvent = (callback: Callback): void =>
+  useWindowEvent(callback, "resize");


### PR DESCRIPTION
# WHY
リサイズ時にコンテンツ数を切り替えるため

# WHAT
## やったこと
- [x] `/hooks/window-events`の作成
