### PR TITLE
React/scroll to top when change page

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter } from "react-router-dom";
 import GlobalStyle from "@/constants/styles/global";
+import { ScrollToTop } from "@/utils";
 
 import App from "@/components/App";
 
@@ -12,6 +13,7 @@ ReactDOM.render(
     <>
       <App />
       <GlobalStyle />
+      <ScrollToTop />
     </>
   </BrowserRouter>,
   document.getElementById("app")

--- a/frontend/src/pages/RadioDetail.tsx
+++ b/frontend/src/pages/RadioDetail.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useState } from "react";
+import React, { Suspense, useState, useEffect } from "react";
 import styled from "styled-components";
 import { useParams, useLocation } from "react-router-dom";
 import { observer } from "mobx-react-lite";
@@ -7,15 +7,16 @@ import { device, color } from "@/constants/styles";
 import { CHK } from "@/constants/url";
 
 import RootStore from "@/stores/RootStore";
+import RadioStore from "@/stores/RadioStore";
 
 import { RadioDetailHeroArea } from "@/components/molecules/HeroArea/RadioDetailHeroArea";
 import TweetStream from "@/components/atoms/Features/TweetStream";
-import PopularRadioWrapper from "@/components/molecules/PopularRadio/PopularRadioWrapper";
+import { PopularRadiosWrapper } from "@/components/molecules/PopularRadio/PopularRadioWrapper";
 import { RadioPlayer } from "@/components/molecules/RadioDetails/RadioPlayer";
 import Personalities from "@/components/molecules/Personalities";
 import { Share } from "@/components/molecules/RadioDetails/Share";
 import CircleSpinner from "@/components/atoms/Spinners/CircleSpinner";
-import RadioStore from "@/stores/RadioStore";
+
 import { IRadio } from "@/api/RadioApi";
 import { PersonalityProfileMiniCard } from "@/components/atoms/FeaturedPersonality/PersonalityProfileMiniCard";
 
@@ -82,6 +83,19 @@ export const RadioDetail = observer((props: { rootStore: RootStore }) => {
 
   const [radio, setRadio] = useState<IRadio | undefined>(undefined);
 
+  useEffect(() => {
+    radioStore.fetchRadios();
+  }, []);
+
+  const [popularRadios, setPopularRadios] = useState<IRadio[] | undefined>(
+    undefined
+  );
+
+  useEffect(() => {
+    const radios = radioStore.shuffledRadios({ limit: 3 });
+    setPopularRadios(radios);
+  }, [radioStore.radios]);
+
   return (
     <div>
       <Suspense fallback={<RadioDetailHeroArea>{""}</RadioDetailHeroArea>}>
@@ -91,7 +105,7 @@ export const RadioDetail = observer((props: { rootStore: RootStore }) => {
       </Suspense>
       <Contrainer>
         <Sidebar>
-          <PopularRadioWrapper />
+          <PopularRadiosWrapper radios={popularRadios} />
           <TweetStream />
         </Sidebar>
         <MainContentWrapper>

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,4 +1,5 @@
 import { isDevelopment } from "./environment";
 import { mapKeysCamelCase } from "./convert-object-keys-to-camelcase";
+import { ScrollToTop } from "./scrollToTop";
 
-export { mapKeysCamelCase, isDevelopment };
+export { mapKeysCamelCase, isDevelopment, ScrollToTop };

--- a/frontend/src/utils/scrollToTop.ts
+++ b/frontend/src/utils/scrollToTop.ts
@@ -1,0 +1,12 @@
+import { FC, useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export const ScrollToTop: FC<{}> = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};


### PR DESCRIPTION
closed #339

# WHY
ページ遷移時にページの一番上じゃないのは違和感があるので

# WHAT
## やったこと
- path が変わると `window.scrollTo(0, 0);` を実行して上部に来るようにした
  - 参考: https://reacttraining.com/react-router/web/guides/scroll-restoration/scroll-to-top
- ラジオ詳細ページでポピュラーラジオが取得できていなかったので修正した

## やってないこと
- 特に無し
