### PR TITLE
webpack dev 用の redirect 設定を行なった

### DIFF
--- a/app/controllers/redirect_webpack_dev_controller.rb
+++ b/app/controllers/redirect_webpack_dev_controller.rb
@@ -1,0 +1,5 @@
+class RedirectWebpackDevController < ApplicationController
+  def index
+    redirect_to request.url.gsub(":3000", ":5000")
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+require "constraint/redirect_webpack_dev"
+
 Rails.application.routes.draw do
   mount_roboto
 
@@ -57,5 +59,11 @@ Rails.application.routes.draw do
     resources :radios
     resources :jargons
     resources :contacts
+  end
+
+  if Rails.env.development?
+    constraints Constraint::RedirectWebpackDev do
+      get "*unmatch_path" => "redirect_webpack_dev#index"
+    end
   end
 end

--- a/lib/constraint/redirect_webpack_dev.rb
+++ b/lib/constraint/redirect_webpack_dev.rb
@@ -1,0 +1,7 @@
+module Constraint
+  class RedirectWebpackDev
+    def self.matches?(request)
+      request.format.symbol == :js && !request.path.start_with?("/assets")
+    end
+  end
+end


### PR DESCRIPTION
## WHY

Rails の port が3000番、webpackdev の port が5000番でズレているのが原因で面倒なことがあるらしい。

# WHAT
## やったこと

.js 拡張子 かつ /assets でない path へリクエストがあったら 5000番に redirect させた。

## やってないこと

特にないはず